### PR TITLE
fix: xray v25.8.3+ compatibility

### DIFF
--- a/marznode/backends/xray/_utils.py
+++ b/marznode/backends/xray/_utils.py
@@ -21,17 +21,27 @@ def get_version(xray_path: str) -> str | None:
 
 def get_x25519(xray_path: str, private_key: str = None) -> Dict[str, str] | None:
     """
-    get x25519 public key using the private key
-    :param xray_path:
-    :param private_key:
-    :return: x25519 publickey
+    Calculates the public key from the provided private key.
+    
+    - Old output format ("Public key:")
+    - New output format ("Password:")
     """
+
     cmd = [xray_path, "x25519"]
     if private_key:
         cmd.extend(["-i", private_key])
     output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode("utf-8")
-    match = re.match(r"Private key: (.+)\nPublic key: (.+)", output)
-    if match:
-        private, public = match.groups()
+
+    # Try New Format (v25.8.3+): Looks for "Password:" instead of Public Key
+    match_new = re.match(r"PrivateKey:\s*(.+)\nPassword:\s*(.+)", output)
+    if match_new:
+        private, public = match_new.groups()
         return {"private_key": private, "public_key": public}
+
+    # Try Old Format (< v25.8.3): Looks for standard "Public key:"
+    match_old = re.match(r"Private key:\s*(.+)\nPublic key:\s*(.+)", output)
+    if match_old:
+        private, public = match_old.groups()
+        return {"private_key": private, "public_key": public}
+
     return None


### PR DESCRIPTION
In recent versions of xray-core , the output of x25519 -i command has changed.
- Old Output: Public key: ...
- New Output: Password: ...

Issue:  the regex in _utils.py failed to match the new output format, causing get_x25519 to return None. This led to a crash during startup when _config.py attempted to access the key.

- Error Log:
```
marznode-1  | 2025-11-22 14:33:41,210 - INFO - marznode.marznode: Generating a keypair for Marznode.
marznode-1  | Traceback (most recent call last):
...
marznode-1  |   File "/app/marznode/backends/xray/xray_backend.py", line 94, in start
marznode-1  |     self._config = XrayConfig(backend_config, api_port=xray_api_port)
marznode-1  |   File "/app/marznode/backends/xray/_config.py", line 55, in __init__
marznode-1  |     self._resolve_inbounds()
marznode-1  |   File "/app/marznode/backends/xray/_config.py", line 142, in _resolve_inbounds
marznode-1  |     settings["pbk"] = x25519["public_key"]
marznode-1  | TypeError: 'NoneType' object is not subscriptable```

fix: updated marznode/backends/xray/_utils.py: Added regex support for new Password: label while maintaining backward compatibility for older xray versions.